### PR TITLE
Mobile compatibility

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1 class="display-1" :class="{'text-white': isDarkMode}">
+    <h1 class="display-4" :class="{'text-white': isDarkMode}">
       Shuttle Tracker <span class="text-muted h4">BETA</span>
     </h1>
   </div>

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div id="map" class="w-100" style="height: 500px;"></div>
+    <div id="map" class="w-100" style="height: 75vh"></div>
   </div>
 </template>
 

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -43,7 +43,7 @@ export default {
     this.mapObj.colorScheme = this.isDarkMode ? mapkit.Map.ColorSchemes.Dark : mapkit.Map.ColorSchemes.Light
     // center map
     const center = new mapkit.Coordinate(42.73029109316892, -73.67655873298646)
-    const span = new mapkit.CoordinateSpan(0.016, 0.016)
+    const span = new mapkit.CoordinateSpan(0.016, 0.032)
     const region = new mapkit.CoordinateRegion(center, span)
     this.mapObj.setRegionAnimated(region)
     // render map structures

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,19 +1,21 @@
 <template>
   <div class="container">
     <div class="row">
-      <div class="col-8">
+      <div class="col">
         <Header></Header>
       </div>
-      <div class="col-4">
-        <Status></Status>
-      </div>
     </div>
-    <div class="row">
+    <div class="row mt-2">
       <div class="col">
         <Tracker></Tracker>
       </div>
     </div>
-    <div class="row">
+    <div class="row mt-3">
+      <div class="col">
+        <Status></Status>
+      </div>
+    </div>
+    <div class="row mt-3">
       <div class="col">
         <Footer></Footer>
       </div>


### PR DESCRIPTION
Closes #4 

- Moved server status below the tracker.
- Scaled down the size of the header/title
- Map height is now 75% of the screen height
- Map now shows the entire campus on mobile devices

![image](https://user-images.githubusercontent.com/29915393/135330125-92b49725-1d52-4d5f-bf6b-9c3f9d6cc1e3.png)