### PR TITLE
add a link to iOS app

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,6 +1,9 @@
 <template>
   <div :class="[{'text-white': isDarkMode}]">
-    This map refreshes every 5 seconds.
+    <span style="float: left">This map refreshes every 5 seconds.</span>
+    <span style="float: right;">
+      <a href="https://testflight.apple.com/join/GsmZkfgd">Download iOS app</a>
+    </span>
   </div>
 </template>
 


### PR DESCRIPTION
Closes #2 
A link to the testflight page of Shuttle Tracker iOS app is added to the Footer, and is aligned to the right.