### PR TITLE
Move footer up and reduce footer text to fit phone resolutions

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -2,7 +2,7 @@
   <div :class="[{'text-white': isDarkMode}]">
     <span style="float: left">This map refreshes every 5 seconds.</span>
     <span style="float: right;">
-      <a href="https://testflight.apple.com/join/GsmZkfgd">Download iOS app</a>
+      <a href="https://testflight.apple.com/join/GsmZkfgd"> iOS App</a>
     </span>
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,11 @@
         <Tracker></Tracker>
       </div>
     </div>
+    <div class="row">
+      <div class="col">
+        <Footer></Footer>
+      </div>
+    </div>
     <div class="row mt-3">
       <div class="col">
         <Status></Status>
@@ -18,11 +23,6 @@
     <div class="row mt-3">
       <div class="col">
         <Schedule></Schedule>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col">
-        <Footer></Footer>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I moved the footer up and update the "Download iOS App" text to just "iOS App".
#10 
![image](https://user-images.githubusercontent.com/90888002/135731721-5095a62d-7302-46b1-82c0-70ec44d30af7.png)
