### PR TITLE
added fake HQ traffic for dev testing

### DIFF
--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -3,15 +3,37 @@
     <b-badge class="mx-1" :variant="serverStatus.routes ? 'success': 'danger'">Routes</b-badge>
     <b-badge class="mx-1" :variant="serverStatus.stops ? 'success': 'danger'">Stops</b-badge>
     <b-badge class="mx-1" :variant="serverStatus.buses ? 'success': 'danger'">Buses</b-badge>
+    <b-form-checkbox v-model="devHQ" name="check-button" switch :class="{'text-white': isDarkMode}">
+      Create Fake HQ data: Bus ( ͡° ͜ʖ ͡°)
+    </b-form-checkbox>
   </div>
 </template>
 
 <script>
 export default {
   name: "Status",
+  data() {
+    return {
+      devHQ: false
+    }
+  },
+  methods: {
+    setHQData() {
+      console.log(this.devHQ)
+      this.$store.commit('setFakeHQ', this.devHQ)
+    }
+  },
+  watch: {
+    devHQ () {
+      this.setHQData()
+    }
+  },
   computed: {
     serverStatus() {
       return this.$store.state.serverStatus
+    },
+    isDarkMode() {
+      return this.$store.state.isDarkMode
     }
   }
 }

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -24,6 +24,9 @@ export default {
     },
     serverStatus() {
       return this.$store.state.serverStatus;
+    },
+    fakeHQ() {
+      return this.$store.state.fakeHQ;
     }
   },
   mounted() {
@@ -57,6 +60,22 @@ export default {
       try {
         // fetch api
         const res = await axios.get(this.baseURL + '/buses')
+        console.log(res.data)
+        // create fake HQ traffic
+        if (this.fakeHQ) {
+          let now = new Date()
+          res.data.push({
+            "id": '( ͡° ͜ʖ ͡°)',
+            "location":
+                {
+                  "coordinate": {"latitude":42.730310,"longitude":-73.685210},
+                  "id":"385FF2A4-EB53-42FE-B754-DAA3DCE04351",
+                  "type":"user",
+                  "date": now.toISOString()
+                }
+          })
+        }
+        console.log(res.data)
         // filter and extract data
         let now = Date.now()
         const buses = res.data

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,7 +10,8 @@ export default new Vuex.Store({
             routes: true,
             stops: true,
             buses: true
-        }
+        },
+        fakeHQ: false
     },
     mutations: {
         setDarkMode(state, darkModeOn) {
@@ -26,6 +27,9 @@ export default new Vuex.Store({
             if (status.buses !== undefined) {
                 state.serverStatus.buses = status.buses
             }
+        },
+        setFakeHQ(state, status) {
+            state.fakeHQ = status
         }
     },
     actions: {},


### PR DESCRIPTION
You can now create fake HQ shuttle traffic for testing purposes, will be removed on production.
![image](https://user-images.githubusercontent.com/29915393/136630482-3d134331-2304-461a-902c-9626ced47da6.png)
This action is not immediate. It'll show/fade next time the bus API is fetched (5 seconds interval).