### PR TITLE
Adjust background color of high-quality bus

### DIFF
--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -93,7 +93,7 @@ export default {
                   if (this.isCbMode) {
                     busIcon = "H"
                   }
-                  color = "springgreen"
+                  color = "mediumseagreen"
                   break;
                 case "system":
                   color = "red"


### PR DESCRIPTION
I changed the background color of the high-quality bus from "springgreen" to "mediumseagreen", which is a bit darker and easier to see the "H" under color-blind mode now.