### PR TITLE
Darkchange (closes #28)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" :class="[{'bg-dark-theme': isDarkMode}]">
+  <div id="app" :class="[{'bg-dark-theme': isDarkMode}, {'bg-light-theme': !isDarkMode}]">
     <router-view/>
   </div>
 </template>
@@ -45,5 +45,8 @@ export default {
 @import "~@/assets/scss/vendors/bootstrap-vue/index";
 .bg-dark-theme {
   background-color: #101214;
+}
+.bg-light-theme {
+  background-color: #FFFFFF;
 }
 </style>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -18,7 +18,7 @@ export default {
   data() {
     return {
       isCbMode: false,
-      isDark: false, //dummy (overwritten by created())
+      isDark: false,
       cbExplanation: "Changes the icons of buses to H and L based on the quality of the bus data",
       darkExplanation: "Switches dark mode on or off",
     }
@@ -34,6 +34,18 @@ export default {
       if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
         this.$store.commit('setDarkMode', true)
       }
+      window.matchMedia('(prefers-color-scheme: dark)')
+        .addEventListener('change', event => {
+        if (event.matches) {
+        // dark mode
+          this.$store.commit('setDarkMode', true)
+          this.isDark = true
+        } else {
+        // light mode
+          this.$store.commit('setDarkMode', false)
+          this.isDark = false
+        }
+      })
     }
   },
   computed: {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -29,6 +29,11 @@ export default {
     },
     setDarkMode() {
       this.$store.commit('setDarkMode', this.isDark)
+    },
+    checkDarkMode() {
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.$store.commit('setDarkMode', true)
+      }
     }
   },
   computed: {
@@ -38,7 +43,7 @@ export default {
   },
   created() {
     this.isCbMode = this.$store.state.isCbMode  // sync state
-    console.log(this.$store.state.isDarkMode)
+    this.checkDarkMode()
     this.isDark = this.$store.state.isDarkMode
   }
 }

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -5,6 +5,10 @@
                      v-b-tooltip.hover.lefttop :title="cbExplanation" switch>
       Colorblind Mode
     </b-form-checkbox>
+    <b-form-checkbox @change="setDarkMode" :class="[{'text-white': isDarkMode}]" v-model="isDark" name="DarkModeSwitch"
+                     v-b-tooltip.hover.lefttop :title="darkExplanation" switch>
+      Dark Mode
+    </b-form-checkbox>
   </div>
 </template>
 
@@ -14,12 +18,17 @@ export default {
   data() {
     return {
       isCbMode: false,
+      isDark: false, //dummy (overwritten by created())
       cbExplanation: "Changes the icons of buses to H and L based on the quality of the bus data",
+      darkExplanation: "Switches dark mode on or off",
     }
   },
   methods: {
     setCbMode() {
       this.$store.commit('setCbMode', this.isCbMode)
+    },
+    setDarkMode() {
+      this.$store.commit('setDarkMode', this.isDark)
     }
   },
   computed: {
@@ -29,6 +38,8 @@ export default {
   },
   created() {
     this.isCbMode = this.$store.state.isCbMode  // sync state
+    console.log(this.$store.state.isDarkMode)
+    this.isDark = this.$store.state.isDarkMode
   }
 }
 </script>

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -63,7 +63,6 @@ export default {
       try {
         // fetch api
         const res = await axios.get(this.baseURL + '/buses')
-        console.log(res.data)
         // create fake HQ traffic
         if (this.fakeHQ) {
           let now = new Date()
@@ -78,7 +77,6 @@ export default {
                 }
           })
         }
-        console.log(res.data)
         // filter and extract data
         let now = Date.now()
         const buses = res.data


### PR DESCRIPTION
Done successfully. The user is able to click on a switch that switches the page between light and dark mode. When the page loads, the default is the system's mode, and if they switch the system's mode, the page and switch update automatically without refreshing.
The very top and bottom of the page remain on system's mode (light/dark), regardless of the manually chosen mode. It may be beyond the scope of the HTML, in which case there may be nothing to be done about it.
![image](https://user-images.githubusercontent.com/90933282/137045270-0e34e793-f3c3-402c-849a-c5d5bea68c0b.png)
