### PR TITLE
Add a copyright footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,5 @@
 <template>
   <div id="app">
-    <link rel="stylesheet"
-          href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"
-          integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ"
-          crossorigin="anonymous">
     <router-view/>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,9 @@
 <template>
   <div id="app">
+    <link rel="stylesheet"
+          href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"
+          integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ"
+          crossorigin="anonymous">
     <router-view/>
   </div>
 </template>

--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -1,0 +1,29 @@
+<template>
+
+  <footer class="text-center" :class="[{'text-white': isDarkMode}]">
+     © 2021
+    <a class="mr-1" :class="[{'text-white': isDarkMode}]" href="https://staging.web.shuttletracker.app">Shuttle Tracker</a>
+    <a class="mx-1" :class="[{'text-white': isDarkMode}]" href="https://github.com/wtg/Shuttle-Tracker-Web">
+      <i class="fab fa-github" ></i>
+    </a>
+    <a class="ml-1" :class="[{'text-white': isDarkMode}]" href="https://rcos.io">An RCOS Project</a>
+  </footer>
+</template>
+
+<script>
+export default {
+  name: "Copyright",
+  computed: {
+    isDarkMode() {
+      return this.$store.state.isDarkMode
+    }
+  }
+}
+</script>
+
+<style scoped>
+a {
+  color: black;
+  text-decoration:none
+}
+</style>

--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -2,7 +2,7 @@
 
   <footer class="text-center" :class="[{'text-white': isDarkMode}]">
      © 2021
-    <a class="mr-1" :class="[{'text-white': isDarkMode}]" href="https://staging.web.shuttletracker.app">Shuttle Tracker</a>
+    <a class="mr-1" :class="[{'text-white': isDarkMode}]" href="https://web.shuttletracker.app">Shuttle Tracker</a>
     <a class="mx-1" :class="[{'text-white': isDarkMode}]" href="https://github.com/wtg/Shuttle-Tracker-Web">
       <i class="fab fa-github" ></i>
     </a>

--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -1,20 +1,24 @@
 <template>
 
   <footer class="text-center" :class="[{'text-white': isDarkMode}]">
-     © 2021
-    <a class="mr-1" :class="[{'text-white': isDarkMode}]" href="https://web.shuttletracker.app">Shuttle Tracker</a>
-    <a class="mx-1" :class="[{'text-white': isDarkMode}]" href="https://github.com/wtg/Shuttle-Tracker-Web">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
-        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
-      </svg>
-    </a>
-    <a class="ml-1" :class="[{'text-white': isDarkMode}]" href="https://rcos.io">An RCOS Project</a>
+    © 2021
+    <b-link class="mr-1" :class="[{'text-white': isDarkMode}, {'text-black': !isDarkMode}]"
+            href="https://github.com/wtg/Shuttle-Tracker-Web/tree/main">
+      Shuttle Tracker
+      <b-icon-github class="mb-1" font-scale="1.25"></b-icon-github>
+      An RCOS project
+    </b-link>
   </footer>
 </template>
 
 <script>
+import {BIconGithub} from 'bootstrap-vue'
+
 export default {
   name: "Copyright",
+  components: {
+    BIconGithub
+  },
   computed: {
     isDarkMode() {
       return this.$store.state.isDarkMode
@@ -24,11 +28,7 @@ export default {
 </script>
 
 <style scoped>
-a {
-  color: black;
-  text-decoration:none
-}
-svg {
-  vertical-align: sub;
+.text-black {
+  color: black !important;
 }
 </style>

--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -4,7 +4,9 @@
      © 2021
     <a class="mr-1" :class="[{'text-white': isDarkMode}]" href="https://web.shuttletracker.app">Shuttle Tracker</a>
     <a class="mx-1" :class="[{'text-white': isDarkMode}]" href="https://github.com/wtg/Shuttle-Tracker-Web">
-      <i class="fab fa-github" ></i>
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+      </svg>
     </a>
     <a class="ml-1" :class="[{'text-white': isDarkMode}]" href="https://rcos.io">An RCOS Project</a>
   </footer>
@@ -25,5 +27,8 @@ export default {
 a {
   color: black;
   text-decoration:none
+}
+svg {
+  vertical-align: sub;
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -29,6 +29,11 @@
           <Settings></Settings>
         </div>
       </div>
+      <div class="row">
+        <div class="col">
+          <Copyright></Copyright>
+        </div>
+      </div>
     </div>
     <Modal></Modal>
   </div>
@@ -43,6 +48,7 @@ import Schedule from "../components/Schedule";
 import Status from "../components/Status";
 import Modal from "../components/Modal";
 import Settings from "../components/Settings";
+import Copyright from "../components/Copyright";
 
 export default {
   name: 'Home',
@@ -53,7 +59,8 @@ export default {
     Schedule,
     Status,
     Modal,
-    Settings
+    Settings,
+    Copyright
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -29,7 +29,7 @@
           <Settings></Settings>
         </div>
       </div>
-      <div class="row">
+      <div class="row mt-3">
         <div class="col">
           <Copyright></Copyright>
         </div>


### PR DESCRIPTION
Closes #29 
The copyright footer now looks like 

<img width="352" alt="image" src="https://user-images.githubusercontent.com/44724621/137550657-c6e973f7-e47c-4e37-96f8-5e72826a6973.png">

, and it supports dark mode.