### PR TITLE
Cleaned up bus schedule list

### DIFF
--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -22,5 +22,8 @@ export default {
 </script>
 
 <style scoped>
-
+  ul {
+    list-style-type: none;
+    padding: 0px 0px 0px 0px;
+  }
 </style>


### PR DESCRIPTION
Closes #52 
Remove the padding and left-justified the bus schedule. Clean up the schedule for better readability.
![image](https://user-images.githubusercontent.com/90888002/138542679-6a366c19-6373-4dbe-90f8-52cb6566f73e.png)
