### PR TITLE
Set eslint rule console-log to warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "parser": "babel-eslint"
     },
     "rules": {
-      "no-undef": "warn"
+      "no-undef": "warn",
+      "no-console": "warn"
     }
   },
   "browserslist": [


### PR DESCRIPTION
New eslint rule to warn about console logging. This is to prevent garbage code and exposing unnecessary information to the users. 