### PR TITLE
Dev tool show announcement bar

### DIFF
--- a/src/components/Announcement.vue
+++ b/src/components/Announcement.vue
@@ -38,6 +38,9 @@ export default {
     isDarkMode() {
       return this.$store.state.isDarkMode
     },
+    devAnnouncement() {
+      return this.$store.state.fakeAnnounce;
+    },
     announcements() {
       // filter out unwanted announcements
       return this.raw.filter((announce) => {
@@ -62,6 +65,12 @@ export default {
       }
     }
   },
+  watch: {
+    // simulates the announcement bar
+    devAnnouncement() {
+      this.getAnnouncements();
+    }
+  },
   methods: {
     async updateAnnouncements() {
       const vm = this
@@ -83,13 +92,18 @@ export default {
       }, this.fetchInterval)
     },
     async getAnnouncements() {
-      //  Fetch raw data from the announcement API
-      const res = await axios.get(this.baseURL + '/announcements')
-      this.raw = res.data
-
-      /* FOR DEBUGGING, MAKES ANNOUNCEMENT BAR VISIBLE */
-      //this.hasAnnouncements = true;
-      //this.announcements[0] = "";
+      // Fetch raw data from the announcement API
+      const res = await axios.get(this.baseURL + '/announcements');
+      this.raw = res.data;
+      // Simulate announcement bar
+      if(this.devAnnouncement) {
+        // Input fake announcement
+        this.announcements[0] = {subject: "Debug", body: "This is a fake announcement."};
+      } else {
+        // Clear announcements. This clears all announcements, so this developer setting can 
+        // also be used to hide the announcement bar when there are actual announcements displayed.
+        this.announcements.splice(0, this.announcements.length);
+      }
 
       if (this.hasAnnouncements) {
         this.$nextTick(this.loadAnnouncer)

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -15,7 +15,7 @@
     </b-form-checkbox>
     <b-form-checkbox v-if="devToolsEnabled" v-model="devAnnouncement" name="AnnouncementBarSwitch" switch
                      :class="{'text-white': isDarkMode}">
-      Simulate Announcement Bar
+      Toggle Fake Announcement Bar
     </b-form-checkbox>
   </b-card>
 </template>
@@ -46,7 +46,7 @@ export default {
       this.$store.commit('setFakeHQ', this.devHQ)
     },
     simulateAnnouncementBar() {
-      this.$store.commit('fakeAnnouncement', this.devAnnouncement)
+      this.$store.commit('fakeAnnouncement', this.devAnnouncement);
     }
   },
   computed: {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -13,6 +13,10 @@
                      :class="{'text-white': isDarkMode}">
       Create Fake HQ data: Bus 69
     </b-form-checkbox>
+    <b-form-checkbox v-if="devToolsEnabled" v-model="devAnnouncement" name="AnnouncementBarSwitch" switch
+                     :class="{'text-white': isDarkMode}">
+      Simulate Announcement Bar
+    </b-form-checkbox>
   </b-card>
 </template>
 
@@ -24,6 +28,7 @@ export default {
       isCbMode: false,
       isDark: false,
       devHQ: false,
+      devAnnouncement: false,
       devToolsEnabled: process.env.VUE_APP_DEV_TOOLS_ENABLED === "true",
       // Explanation Message when hovering over setting sliders
       cbExplanation: "Changes the icons of buses to + and ! based on the quality of the bus data",
@@ -39,6 +44,9 @@ export default {
     },
     setHQData() {
       this.$store.commit('setFakeHQ', this.devHQ)
+    },
+    simulateAnnouncementBar() {
+      this.$store.commit('fakeAnnouncement', this.devAnnouncement)
     }
   },
   computed: {
@@ -52,6 +60,9 @@ export default {
     },
     devHQ() {
       this.setHQData()
+    },
+    devAnnouncement() {
+      this.simulateAnnouncementBar();
     }
   },
   mounted() {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,7 +14,8 @@ export default new Vuex.Store({
             buses: true,
             version: true
         },
-        fakeHQ: false
+        fakeHQ: false,
+        fakeAnnounce: false
     },
     // Functions to alter the website states
     mutations: {
@@ -50,6 +51,10 @@ export default new Vuex.Store({
         // Set a fake bus for development purposes
         setFakeHQ(state, status) {
             state.fakeHQ = status
+        },
+        // Show a fake announcement bar for development purposes
+        fakeAnnouncement(state, status) {
+            state.fakeAnnounce = status;
         }
     },
     actions: {},


### PR DESCRIPTION
Closes #106 
Added a switch to toggle on and off announcement bar and simulate a fake announcement. The switch is only visible if dev tools are enabled (process.env.VUE_APP_DEV_TOOLS_ENABLED == true).
![image](https://user-images.githubusercontent.com/82001942/154151023-24ce2566-f7c0-4019-a0b7-4cac4a10aee2.png)
