### PR TITLE
Elements now hide upon entering fullscreen (firefox bug)

### DIFF
--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -1,6 +1,7 @@
 <template>
 
-  <footer class="text-center" :class="[{'text-white': isDarkMode}]">
+  <footer v-if="isFsMode"
+  class="text-center" :class="[{'text-white': isDarkMode}]">
     © 2021
     <b-link class="mr-1" :class="[{'text-white': isDarkMode}, {'text-black': !isDarkMode}]"
             href="https://github.com/wtg/Shuttle-Tracker-Web/tree/main">
@@ -39,6 +40,9 @@ export default {
   computed: {
     isDarkMode() {
       return this.$store.state.isDarkMode
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
     }
   }
 }

--- a/src/components/Fullscrn_qrcode.vue
+++ b/src/components/Fullscrn_qrcode.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card
+  <b-card v-if="isFsMode"
     class="mt-3"
     :class="[{ 'bubble-dark': isDarkMode }, { 'bubble-light': !isDarkMode }]"
   >
@@ -23,6 +23,9 @@ export default {
     isDarkMode() {
       return this.$store.state.isDarkMode;
     },
+    isFsMode() {
+      return !this.$store.state.isFsMode
+    }
   },
 };
 </script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="isFsMode">
     <h1 class="display-4" :class="{'text-white': isDarkMode}">
       Shuttle Tracker <span v-if="showBeta" class="text-muted h4">BETA</span>
     </h1>
@@ -17,6 +17,9 @@ export default {
   computed: {
     isDarkMode() {
       return this.$store.state.isDarkMode
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
     }
   }
 }

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
+  <b-card v-if="isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
     <h3 :class="{'text-white': isDarkMode}">
       Spring 2022 Schedule
     </h3>
@@ -16,6 +16,9 @@ export default {
   computed: {
     isDarkMode() {
       return this.$store.state.isDarkMode
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
     }
   }
 }

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
+  <b-card v-if="isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
     <h3 :class="{'text-white': isDarkMode}">Settings</h3>
     <b-form-checkbox @change="setCbMode" :class="[{'text-white': isDarkMode}]" v-model="isCbMode" name="cbModeSwitch"
                      v-b-tooltip.hover.lefttop :title="cbExplanation" switch>
@@ -52,6 +52,9 @@ export default {
   computed: {
     isDarkMode() {
       return this.$store.state.isDarkMode
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
     }
   },
   watch: {

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -68,6 +68,9 @@ export default {
     },
     fakeHQ() {
       return this.$store.state.fakeHQ;
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
     }
   },
   mounted() {
@@ -111,6 +114,7 @@ export default {
     },
     toggleFullscreen() {
       this.fullscreen = !this.fullscreen
+      this.$store.commit('setFsMode', this.fullscreen);
       this.fixRoundedBorders()  // remove/apply rounded corners on the map
     },
     fixRoundedBorders() {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ export default new Vuex.Store({
     state: {
         isDarkMode: false,
         isCbMode: false,
+        isFsMode: false,
         serverStatus: {
             routes: true,
             stops: true,
@@ -55,6 +56,10 @@ export default new Vuex.Store({
         // Show a fake announcement bar for development purposes
         fakeAnnouncement(state, status) {
             state.fakeAnnounce = status;
+        },
+        // Set fullscreen mode
+        setFsMode(state, status) {
+            state.isFsMode = status;
         }
     },
     actions: {},


### PR DESCRIPTION
Closes #121 
Below is it in action. Note that I manually slowed mozilla's fullscreen speed in about:config for the example so that it would be easier to see, but obviously it still works with default mozilla settings:

https://user-images.githubusercontent.com/82001942/156268193-ad690f83-311e-43aa-b18c-c20ac77f8be7.mp4

!!! The server status and enter fullscreen buttons still show up. I'm going to make a separate issue for this. The fix for the issue is different from what I just did because the same buttons are used to exit fullscreen, so I would have to hide them and then make them reappear after the firefox fullscreen animation. 