### PR TITLE
Fixed schedule loop bug

### DIFF
--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -48,7 +48,7 @@ export default {
 				"end": "23:00"
 			}
 		},
-      currentSemester: undefined
+      currentSemester: "Spring 2022"
     };
   },
   /**
@@ -83,6 +83,7 @@ export default {
         if (this.schedules[i].start <= current.toISOString() && this.schedules[i].end >= current.toISOString()) {
           this.currentWeek = this.schedules[i].content;
           this.currentSemester = this.schedules[i].name;
+          break;
         }
       }
     }


### PR DESCRIPTION
Added a break to the loop once current schedule is found

I also initialized currentSemester variable so when website loaded it isn't blank for a fraction of a second