### PR TITLE
Custom API base URL and advanced settings

### DIFF
--- a/src/components/AdvanceSettings.vue
+++ b/src/components/AdvanceSettings.vue
@@ -1,6 +1,10 @@
 <template>
   <b-card v-if="isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
     <h3 :class="{'text-white': isDarkMode}">Advance Settings</h3>
+<!--    <label for="input-custom-api">Custom API:</label><b-form-input id="input-custom-api" size="sm">HELLO</b-form-input>-->
+    <b-form-group :label-class="{'text-white': isDarkMode}" label="Custom API:" label-for="input-custom-api">
+      <b-form-input @change="setBaseURL" id="input-custom-api" v-model="customAPI" size="sm" placeholder="Blank for default" debounce="500"></b-form-input>
+    </b-form-group>
   </b-card>
 </template>
 
@@ -9,7 +13,7 @@ export default {
   name: "AdvanceSettings",
   data() {
     return {
-      devToolsEnabled: process.env.VUE_APP_DEV_TOOLS_ENABLED === "true",
+      customAPI: ''
     }
   },
   computed: {
@@ -26,6 +30,16 @@ export default {
   watch: {
     isDarkMode(val) {
       this.isDark = val // dynamically sync state
+    }
+  },
+  methods: {
+    // change custom API URL
+    setBaseURL() {
+      if (this.customAPI.trim() === '') {
+        this.$store.commit('restoreBaseURL')
+      } else {
+        this.$store.commit('setBaseURL', this.customAPI)
+      }
     }
   }
 }

--- a/src/components/AdvanceSettings.vue
+++ b/src/components/AdvanceSettings.vue
@@ -1,0 +1,52 @@
+<template>
+  <b-card v-if="isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
+    <h3 :class="{'text-white': isDarkMode}">Advance Settings</h3>
+  </b-card>
+</template>
+
+<script>
+export default {
+  name: "AdvanceSettings",
+  data() {
+    return {
+      devToolsEnabled: process.env.VUE_APP_DEV_TOOLS_ENABLED === "true",
+    }
+  },
+  computed: {
+    isDarkMode() {
+      return this.$store.state.isDarkMode
+    },
+    isFsMode() {
+      return !this.$store.state.isFsMode
+    },
+    isAdvMode() {
+      return this.$store.state.isAdvMode
+    },
+  },
+  watch: {
+    isDarkMode(val) {
+      this.isDark = val // dynamically sync state
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+.card {
+  border-radius: 7px;
+}
+.card-body {
+  padding: 1rem;
+  opacity: 0.8;
+}
+.bubble-light {
+  background-color: rgb(235, 235, 235);
+  border-color: rgb(235, 235, 235);
+}
+
+.bubble-dark {
+  background-color: rgb(71, 71, 71);
+  border-color: rgb(71, 71, 71);
+}
+</style>

--- a/src/components/AdvanceSettings.vue
+++ b/src/components/AdvanceSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card v-if="isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
-    <h3 :class="{'text-white': isDarkMode}">Advance Settings</h3>
+    <h3 :class="{'text-white': isDarkMode}">Advanced Settings</h3>
 <!--    <label for="input-custom-api">Custom API:</label><b-form-input id="input-custom-api" size="sm">HELLO</b-form-input>-->
     <b-form-group :label-class="{'text-white': isDarkMode}" label="Custom API:" label-for="input-custom-api">
       <b-form-input @change="setBaseURL" id="input-custom-api" v-model="customAPI" size="sm" placeholder="Blank for default" debounce="500"></b-form-input>

--- a/src/components/Announcement.vue
+++ b/src/components/Announcement.vue
@@ -29,12 +29,14 @@ export default {
       updateOnNextInterval: false,
       fetchInterval: parseInt(process.env.VUE_APP_ANNOUNCEMENT_UPDATE_INTERVAL), // update announcement every minute
       announcerIndex: 0,
-      baseURL: process.env.VUE_APP_API_BASE_URL,
       rawUpdate: [],  // temporarily stores updated announcements
       raw: []
     }
   },
   computed: {
+    baseURL() {
+      return this.$store.state.baseURL
+    },
     isDarkMode() {
       return this.$store.state.isDarkMode
     },
@@ -100,7 +102,7 @@ export default {
         // Input fake announcement
         this.announcements[0] = {subject: "Debug", body: "This is a fake announcement."};
       } else {
-        // Clear announcements. This clears all announcements, so this developer setting can 
+        // Clear announcements. This clears all announcements, so this developer setting can
         // also be used to hide the announcement bar when there are actual announcements displayed.
         this.announcements.splice(0, this.announcements.length);
       }
@@ -130,20 +132,20 @@ export default {
   beforeMount()
   {
     /*** handles mouse down and touch down **/
-    let pauseAnim = () => { 
-      document.querySelector(".scroll-left .scroll-text").style.setProperty("--animState", "paused"); 
+    let pauseAnim = () => {
+      document.querySelector(".scroll-left .scroll-text").style.setProperty("--animState", "paused");
     }
     // add event listeners for pausing the animation
     "mousedown touchstart".split(" ").forEach(function(e){document.addEventListener(e, pauseAnim, false)});
 
     /*** handles mouse up and touch release ***/
-    let resumeAnim = () => { 
-      document.querySelector(".scroll-left .scroll-text").style.setProperty("--animState", "running"); 
+    let resumeAnim = () => {
+      document.querySelector(".scroll-left .scroll-text").style.setProperty("--animState", "running");
     }
     // add event listeners for resuming the animation
     "mouseup touchend".split(" ").forEach(function(e){document.addEventListener(e, resumeAnim, false)});
   },
-  
+
   mounted() {
     this.getAnnouncements();
     this.updateAnnouncements();

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -56,6 +56,9 @@ export default {
    * @return{boolean} The dark mode status
    */
   computed: {
+    baseURL() {
+      return this.$store.state.baseURL
+    },
     isDarkMode() {
       return this.$store.state.isDarkMode
     },
@@ -70,7 +73,7 @@ export default {
     async getCurrentSemester() {
 
       // Gets API
-      const response = await axios.get("https://shuttletracker.app/schedule.json")
+      const response = await axios.get(this.baseURL + "/schedule.json")
 
       // API goes in here
       this.schedules = response.data

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -11,7 +11,7 @@
     </b-form-checkbox>
     <b-form-checkbox  @change="setAdvMode" :class="[{'text-white': isDarkMode}]" v-model="isAdvMode" name="AdvModeSwitch"
                       v-b-tooltip.hover.lefttop :title="advSettingsExplanation" switch>
-      Enable Advance Settings
+      Enable Advanced Settings
     </b-form-checkbox>
     <b-form-checkbox v-if="devToolsEnabled" v-model="devHQ" name="check-button" switch
                      :class="{'text-white': isDarkMode}">
@@ -38,7 +38,7 @@ export default {
       // Explanation Message when hovering over setting sliders
       cbExplanation: "Changes the icons of buses to + and ! based on the quality of the bus data",
       darkExplanation: "Switches dark mode on or off",
-      advSettingsExplanation: "Enable advance settings",
+      advSettingsExplanation: "Enable advanced settings",
     }
   },
   methods: {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -9,6 +9,10 @@
                      v-b-tooltip.hover.lefttop :title="darkExplanation" switch>
       Dark Mode
     </b-form-checkbox>
+    <b-form-checkbox  @change="setAdvMode" :class="[{'text-white': isDarkMode}]" v-model="isAdvMode" name="AdvModeSwitch"
+                      v-b-tooltip.hover.lefttop :title="advSettingsExplanation" switch>
+      Enable Advance Settings
+    </b-form-checkbox>
     <b-form-checkbox v-if="devToolsEnabled" v-model="devHQ" name="check-button" switch
                      :class="{'text-white': isDarkMode}">
       Create Fake HQ data: Bus 69
@@ -27,12 +31,14 @@ export default {
     return {
       isCbMode: false,
       isDark: false,
+      isAdvMode: false,
       devHQ: false,
       devAnnouncement: false,
       devToolsEnabled: process.env.VUE_APP_DEV_TOOLS_ENABLED === "true",
       // Explanation Message when hovering over setting sliders
       cbExplanation: "Changes the icons of buses to + and ! based on the quality of the bus data",
       darkExplanation: "Switches dark mode on or off",
+      advSettingsExplanation: "Enable advance settings",
     }
   },
   methods: {
@@ -47,6 +53,9 @@ export default {
     },
     simulateAnnouncementBar() {
       this.$store.commit('fakeAnnouncement', this.devAnnouncement);
+    },
+    setAdvMode() {
+      this.$store.commit('setAdvMode', this.isAdvMode)
     }
   },
   computed: {
@@ -71,6 +80,7 @@ export default {
   mounted() {
     this.isCbMode = this.$store.state.isCbMode  // sync state
     this.isDark = this.$store.state.isDarkMode
+    this.isAdvMode = this.$store.state.isAdvMode
   }
 }
 </script>
@@ -80,10 +90,12 @@ export default {
 .card {
   border-radius: 7px;
 }
+
 .card-body {
   padding: 1rem;
   opacity: 0.8;
 }
+
 .bubble-light {
   background-color: rgb(235, 235, 235);
   border-color: rgb(235, 235, 235);

--- a/src/components/Status.vue
+++ b/src/components/Status.vue
@@ -22,6 +22,7 @@
         API
       </b-badge>
     </div>
+    <b-badge v-if="!isOfficialURL" role="button" class="mx-1" variant="warning" v-b-tooltip.hover :title="NonOfficialWarning">Non-Official API</b-badge>
   </div>
 </template>
 
@@ -33,12 +34,16 @@ export default {
       expanded: false,
       compStatus: "If the badge is green, this component is working!",
       APIWarning: "If the badge is red, the app may be broken. You have been warned.",
+      NonOfficialWarning: "You are using the non-official API, which may result in broken features.",
       statusDescription: "Click to see detailed report on server status."
     }
   },
   computed: {
+    isOfficialURL() {
+      return this.$store.state.isOfficialURL
+    },
     /**
-     * Checks each separate status to determin server status
+     * Checks each separate status to determine server status
      * @return{boolean} False if at least one of the statuses are offline
      */
     totalServerStatus() {

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -47,7 +47,6 @@ export default {
     return {
       routesInterval: undefined,  // for handling request failures
       stopsInterval: undefined,  // for handling request failures
-      baseURL: process.env.VUE_APP_API_BASE_URL,
       mapObj: undefined,
       tokenID: process.env.VUE_APP_MAP_TOKEN_ID,
       apiVersion: process.env.VUE_APP_API_VERSION,
@@ -57,6 +56,9 @@ export default {
     }
   },
   computed: {
+    baseURL() {
+      return this.$store.state.baseURL;
+    },
     isDarkMode() {
       return this.$store.state.isDarkMode;
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -19,7 +19,8 @@ export default new Vuex.Store({
         fakeAnnounce: false,
         defaultURL: process.env.VUE_APP_API_BASE_URL,   // keeps track of the default URL, immutable in run time
         baseURL: process.env.VUE_APP_API_BASE_URL,  // the baseURL that the API calls follows, mutable
-        isOfficialURL: true // indicates is the API is the official one or not
+        isOfficialURL: true, // indicates is the API is the official one or not
+        isAdvMode: false    // indicates whether advance settings are enabled
     },
     // Functions to alter the website states
     mutations: {
@@ -73,6 +74,10 @@ export default new Vuex.Store({
         restoreBaseURL(state) {
             state.baseURL = this.state.defaultURL
             state.isOfficialURL = true
+        },
+        // Enable / Disable advance setting tab
+        setAdvMode(state, status){
+            state.isAdvMode = status
         }
     },
     actions: {},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -16,7 +16,8 @@ export default new Vuex.Store({
             version: true
         },
         fakeHQ: false,
-        fakeAnnounce: false
+        fakeAnnounce: false,
+        baseURL: process.env.VUE_APP_API_BASE_URL
     },
     // Functions to alter the website states
     mutations: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,7 +17,9 @@ export default new Vuex.Store({
         },
         fakeHQ: false,
         fakeAnnounce: false,
-        baseURL: process.env.VUE_APP_API_BASE_URL
+        defaultURL: process.env.VUE_APP_API_BASE_URL,   // keeps track of the default URL, immutable in run time
+        baseURL: process.env.VUE_APP_API_BASE_URL,  // the baseURL that the API calls follows, mutable
+        isOfficialURL: true // indicates is the API is the official one or not
     },
     // Functions to alter the website states
     mutations: {
@@ -61,6 +63,16 @@ export default new Vuex.Store({
         // Set fullscreen mode
         setFsMode(state, status) {
             state.isFsMode = status;
+        },
+        // Set baseURL for the APIs
+        setBaseURL(state, newURL) {
+            state.baseURL = newURL
+            state.isOfficialURL = false
+        },
+        // Set baseURL back to default
+        restoreBaseURL(state) {
+            state.baseURL = this.state.defaultURL
+            state.isOfficialURL = true
         }
     },
     actions: {},

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -18,6 +18,9 @@
         <div class="col-md">
           <Settings></Settings>
         </div>
+        <div v-if="isAdvMode" class="col-md">
+          <AdvanceSettings></AdvanceSettings>
+        </div>
       </div>
       <div class="row mt-3">
         <div class="col">
@@ -41,6 +44,7 @@ import ColorBlindIconModal from "../components/ColorBlindIconModal";
 import Settings from "../components/Settings";
 import Copyright from "../components/Copyright";
 import Announcement from "../components/Announcement";
+import AdvanceSettings from "../components/AdvanceSettings";
 
 export default {
   name: 'Home',
@@ -53,6 +57,12 @@ export default {
     Settings,
     Copyright,
     Announcement,
+    AdvanceSettings
+  },
+  computed: {
+    isAdvMode() {
+      return this.$store.state.isAdvMode
+    }
   }
 }
 </script>


### PR DESCRIPTION
Closes #111 
One would be able to customize the API base URL by enabling the advance settings tab.

![image](https://user-images.githubusercontent.com/29915393/158029257-deffdf89-f151-45df-86ce-188158de8cf1.png)

A badge will remind the user that it is using the non-official API.
![image](https://user-images.githubusercontent.com/29915393/158029295-69ed0a15-6fde-4044-ab9c-3c124d309c04.png)

There are still several tasks left undo, which I will open another issue for:
- Store custom API to cookies
- Flexible URL parsing (`shuttle-tracker.app/api` should be the same as `shuttle-tracker.app/api/`)
