### PR TITLE
Schedule times formatting

### DIFF
--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -5,8 +5,8 @@
     </h3>
     <ul :class="{'text-white': isDarkMode}">
       <li> Weekdays: {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
-      <li> Saturday:<span style="margin-left: 13.5px">{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
-      <li> Sunday:<span style="margin-left: 23.5px">{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
+      <li> Saturday:<span class='saturday-times'>{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
+      <li> Sunday:<span class='sunday-times'>{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
     </ul>
   </b-card>
 </template>
@@ -122,7 +122,11 @@ ul {
   border-color: rgb(71, 71, 71);
 }
 
-.list-schedule {
-  float: right;
+.saturday-times {
+  margin-left: 13.5px;
+}
+
+.sunday-times {
+  margin-left: 23.5px;
 }
 </style>

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -5,8 +5,8 @@
     </h3>
     <ul :class="{'text-white': isDarkMode}">
       <li> Weekdays: {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
-      <li> Saturday:<span style="margin-left: 13px">{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
-      <li> Sunday: <span style="margin-left: 18.5px">{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
+      <li> Saturday:<span style="margin-left: 13.5px">{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
+      <li> Sunday:<span style="margin-left: 23.5px">{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
     </ul>
   </b-card>
 </template>

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -4,9 +4,9 @@
       {{currentSemester}} Schedule
     </h3>
     <ul :class="{'text-white': isDarkMode}">
-      <li> Monday - Friday {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
-      <li> Saturday {{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</li>
-      <li> Sunday {{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</li>
+      <li> Weekdays: {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
+      <li> Saturday:<span style="margin-left: 13px">{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
+      <li> Sunday: <span style="margin-left: 18.5px">{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
     </ul>
   </b-card>
 </template>
@@ -120,5 +120,9 @@ ul {
 .bubble-dark {
   background-color: rgb(71, 71, 71);
   border-color: rgb(71, 71, 71);
+}
+
+.list-schedule {
+  float: right;
 }
 </style>


### PR DESCRIPTION
Changed "Monday - Friday" to "Weekdays".
The times for Saturday and Sunday now align with the Weekdays time.
![weekdays](https://user-images.githubusercontent.com/31413744/160706842-6bc0f8df-c7a4-4e94-87f2-723001c9483c.PNG)

