### PR TITLE
components now hide for safari users when fullscreening

### DIFF
--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -138,6 +138,11 @@ export default {
     if (f > -1) {
       this.fullscreenDelay = 200; // delay to show icons for firefox users, since firefox has fullscreen animation by default
     }
+    var s = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // detect if browser is safari
+    if(s) {
+      this.fullscreenDelay = 200; // delay to show icons for safari users, since safari has fullscreen animation.
+      // NOTE: I have no idea what the default delay is for safari so I just set it to 200
+    }
   },
   methods: {
     isMobile() {


### PR DESCRIPTION
Closes #160 

I don't know what the default delay for safari is as I dont have safari, so I just set it to 200ms (firefox's fullscreen anim is 200ms). I couldn't find exact times on google, so it may be too fast or too slow.