### PR TITLE
Fix misplaced announcement bar

### DIFF
--- a/src/components/Announcement.vue
+++ b/src/components/Announcement.vue
@@ -1,8 +1,8 @@
 <template>
   <b-alert
       v-model="hasAnnouncements"
-      :class="[{'announcement-dark': isDarkMode}, {'announcement-light': !isDarkMode}, 
-      {'fixed-top': isFsMode}, {'fixed-bottom': !isFsMode}]"
+      :class="[{'announcement-dark': isDarkMode}, {'announcement-light': !isDarkMode},
+      {'fixed-top': !isFsMode}, {'fixed-bottom': isFsMode}]"
       class="position-fixed m-0 rounded-0 p-0 py-2 border-0"
       style="z-index: 2000;">
     <div ref="announcer" class="scroll-left">


### PR DESCRIPTION
Announcement now sticks to top in normal mode, and sticks to bottom in fullscreen mode.