### PR TITLE
New privacy policy page

### DIFF
--- a/src/components/Copyright.vue
+++ b/src/components/Copyright.vue
@@ -20,6 +20,10 @@
               target="_blank">
         <small>Android App</small>
       </b-link>
+      <b-link :class="[{'text-black': !isDarkMode}, {'text-gray': isDarkMode}]"
+              to="/privacy-policy">
+        <small>Privacy Policy</small>
+      </b-link>
     </div>
   </footer>
 </template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
+import PrivacyPolicy from "../views/PrivacyPolicy";
 
 Vue.use(VueRouter)
 
@@ -9,6 +10,11 @@ const routes = [
     path: '/',
     name: 'Home',
     component: Home
+  },
+  {
+    path: '/privacy-policy',
+    name: 'PrivacyPolicy',
+    component: PrivacyPolicy
   }
 ]
 

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <div class="container">
+      <div class="row">
+        <div class="col">
+          <Header></Header>
+        </div>
+      </div>
+      <div>
+        <div class="row">
+          <div class="col">
+            <h2 class="text-white">Privacy Policy</h2>
+            <p class="text-white">
+              Shuttle Tracker sends your location data to our server only when you tap “Board Bus” and stops sending these data when you tap “Leave Bus”. Your location data are associated with an anonymous, random identifier that rotates every time you start a new shuttle trip. These data aren’t associated with your name, email address, Apple ID, RCS ID, Google account, or any other identifying information. We continuously purge location data that are more than 30 seconds old from our server. We may retain resolved location data that are calculated using a combination of system- and user-reported data indefinitely, but these resolved data don’t correspond with any specific user-reported coordinates.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Header from "../components/Header";
+
+export default {
+  name: "PrivacyPolicy",
+  components: {
+    Header
+  }
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
Closes #178 
Go to `/privacy-policy` for the privacy policy page. Link is also available in the footer.
![image](https://user-images.githubusercontent.com/29915393/193352674-82e14a7a-5de6-424e-8325-cdb9e4f180d2.png)
The page looks like this
![image](https://user-images.githubusercontent.com/29915393/193352713-1198f013-c112-44a8-9909-e04f5ab3f1d6.png)
