### PR TITLE
Fixed display error and added display for no schedule

### DIFF
--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -53,8 +53,6 @@ export default {
 
       const current = new Date();
 
-      this.currentWeek = undefined
-
       // Checking if current time is between schedule start and end dates
       for (let i = 0; i < this.schedules.length; i++) {
         if (this.schedules[i].start <= current.toISOString() && this.schedules[i].end >= current.toISOString()) {

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -1,10 +1,7 @@
 <template>
   <b-card v-if="!isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
-    <h3 v-if="!isCurrent" :class="{'text-white': isDarkMode}">
-      No Current Schedule
-    </h3>
-    <h3 v-if="isCurrent" :class="{'text-white': isDarkMode}">
-      {{currentSemester}} Schedule
+    <h3 :class="{'text-white': isDarkMode}">
+      {{ !isCurrent ? 'No Current Schedule' : currentSemester + ' Schedule' }}
     </h3>
     <ul v-if="isCurrent" :class="{'text-white': isDarkMode}">
       <li> Weekdays: {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
@@ -23,36 +20,7 @@ export default {
   data() {
     return {
       schedules: [],
-      currentWeek: {
-			"monday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"tuesday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"wednesday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"thursday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"friday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"saturday": {
-				"start": "01:00",
-				"end": "23:00"
-			},
-			"sunday": {
-				"start": "01:00",
-				"end": "23:00"
-			}
-		},
+      currentWeek: undefined,
       currentSemester: "Spring 2022"
     };
   },
@@ -68,9 +36,7 @@ export default {
      * @return if there is no current schedule
      */
     isCurrent() {
-      if (!this.currentWeek) { return false}
-
-      return true
+      return !(this.currentWeek === undefined)
     }
   },
   methods: {
@@ -87,7 +53,7 @@ export default {
 
       const current = new Date();
 
-      this.currentWeek = null
+      this.currentWeek = undefined
 
       // Checking if current time is between schedule start and end dates
       for (let i = 0; i < this.schedules.length; i++) {

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -21,7 +21,7 @@ export default {
     return {
       schedules: [],
       currentWeek: undefined,
-      currentSemester: "Spring 2022"
+      currentSemester: undefined
     };
   },
   computed: {

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -1,9 +1,12 @@
 <template>
-  <b-card v-if="!isFsMode && isCurrent" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
-    <h3 :class="{'text-white': isDarkMode}">
+  <b-card v-if="!isFsMode" class="mt-3" :class="[{'bubble-dark': isDarkMode},{'bubble-light': !isDarkMode}]">
+    <h3 v-if="!isCurrent" :class="{'text-white': isDarkMode}">
+      No Current Schedule
+    </h3>
+    <h3 v-if="isCurrent" :class="{'text-white': isDarkMode}">
       {{currentSemester}} Schedule
     </h3>
-    <ul :class="{'text-white': isDarkMode}">
+    <ul v-if="isCurrent" :class="{'text-white': isDarkMode}">
       <li> Weekdays: {{currentWeek.monday.start}} - {{currentWeek.monday.end}}</li>
       <li> Saturday:<span class='saturday-times'>{{currentWeek.saturday.start}} - {{currentWeek.saturday.end}}</span></li>
       <li> Sunday:<span class='sunday-times'>{{currentWeek.sunday.start}} - {{currentWeek.sunday.end}}</span></li>
@@ -65,21 +68,9 @@ export default {
      * @return if there is no current schedule
      */
     isCurrent() {
-      if (Object.keys(this.schedules).length == 0) { return false }
+      if (!this.currentWeek) { return false}
 
-      //look for current schedule
-      Object.keys(this.schedules).map(idx => {
-
-        //assign current schedule and enable display
-        if (Date.parse(this.schedules[idx]["end"]) <= Date.parse(Date()) &&
-            Date.parse(this.schedules[idx]["start"]) >= Date.parse(Date()))
-        {
-          this.currentWeek = this.schedules[idx]["content"]
-          return true
-        } 
-      })
-
-      return false
+      return true
     }
   },
   methods: {
@@ -96,6 +87,8 @@ export default {
 
       const current = new Date();
 
+      this.currentWeek = null
+
       // Checking if current time is between schedule start and end dates
       for (let i = 0; i < this.schedules.length; i++) {
         if (this.schedules[i].start <= current.toISOString() && this.schedules[i].end >= current.toISOString()) {
@@ -104,6 +97,7 @@ export default {
           break;
         }
       }
+
     }
   },
   mounted () {


### PR DESCRIPTION
Closes #192 

Now properly hides the schedule when there is no current one and displays if there is. If there is no schedule, displays a template error message.

![image](https://user-images.githubusercontent.com/94411052/197295171-780dbce1-86db-4a55-9eff-0e5d94435213.png)

![image](https://user-images.githubusercontent.com/94411052/197295214-04f3f435-cd21-4dcf-b21a-1fe1bec40291.png)
